### PR TITLE
Bump up version of the checkout Github Action

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.2.0
       - name: Run the formatter, linter, and vetter
         uses: dell/common-github-actions/go-code-formatter-linter-vetter@main
         with:
@@ -22,7 +22,7 @@ jobs:
       GO111MODULE: on
     steps:
       - name: Checkout Source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.2.0
       - name: Run Gosec Security Scanner
         uses: securego/gosec@master
         with:
@@ -33,7 +33,7 @@ jobs:
       runs-on: ubuntu-latest
       steps:
         - name: Checkout the code
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3.2.0
         - name: Malware Scanner
           uses: dell/common-github-actions/malware-scanner@main
           with:
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.2.0
       - name: Run the forbidden words scan
         uses: dell/common-github-actions/code-sanitizer@main
         with:
@@ -56,7 +56,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.2.0
       - name: Run unit tests and check package coverage
         uses: dell/common-github-actions/go-code-tester@main
         with:
@@ -74,7 +74,7 @@ jobs:
       with:
         go-version: ^1.19
         id: go
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v3.2.0
     - run: docker build --build-arg BASEIMAGE=$BASEIMAGE --build-arg DIGEST=$DIGEST . -t cosi-driver:latest
     - uses: Azure/container-scan@v0
       env: 


### PR DESCRIPTION
<!--
# Copyright © 2023 Dell Inc. or its subsidiaries. All Rights Reserved.
# 
# Licensed under the Apache License, Version 2.0 (the "License");
# you may not use this file except in compliance with the License.
# You may obtain a copy of the License at
#      http://www.apache.org/licenses/LICENSE-2.0
# Unless required by applicable law or agreed to in writing, software
# distributed under the License is distributed on an "AS IS" BASIS,
# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
# See the License for the specific language governing permissions and
# limitations under the License
-->

# Description
This PR updates the version of the `checkout` Github Action, due to security reasons and phasing out of the older version.

https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/
