### PR TITLE
Increase code coverage in bucket creation feature

### DIFF
--- a/pkg/provisioner/provisioner_test.go
+++ b/pkg/provisioner/provisioner_test.go
@@ -126,6 +126,19 @@ func testDriverCreateBucket(t *testing.T) {
 				"X-TEST/Buckets/Get/force-fail": "abc",
 			},
 		},
+		{
+			description:   "cannot create bucket",
+			inputName:     "FORCEFAIL-bucket-valid",
+			expectedError: status.Error(codes.Internal, "Bucket was not sucessfully created"),
+			server: Server{
+				mgmtClient: fake.NewClientSet(),
+				namespace:  namespace,
+				backendID:  testID,
+			},
+			parameters: map[string]string{
+				"clientID": testID,
+			},
+		},
 	}
 
 	for _, scenario := range testCases {


### PR DESCRIPTION
<!--
# Copyright © 2023 Dell Inc. or its subsidiaries. All Rights Reserved.
# 
# Licensed under the Apache License, Version 2.0 (the "License");
# you may not use this file except in compliance with the License.
# You may obtain a copy of the License at
#      http://www.apache.org/licenses/LICENSE-2.0
# Unless required by applicable law or agreed to in writing, software
# distributed under the License is distributed on an "AS IS" BASIS,
# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
# See the License for the specific language governing permissions and
# limitations under the License
-->

# Description
Increase code coverage in bucket creation feature connected with `Bucket was not sucessfully created` message.

> **⚠ Warning**: 
> All changes in `vendor` directory should be placed in separate PRs. Remember about simultaneous merging branches with **vendor** changes and **functionality** changes.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Unit testing
- [ ] Integration testing

# Special Notes For Your Reviewer:
Please describe the parts of code reviewers should focus on.

# Additional documentation
- [ ] Enhancement proposals
- [ ] Usage documentation