### PR TITLE
chore: updated vendor with goobjectscale

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/aws/aws-sdk-go v1.44.232
-	github.com/dell/goobjectscale v0.0.0-20230406105044-0add239e0a89
+	github.com/dell/goobjectscale v0.0.0-20230502124457-3303009b54d8
 	github.com/onsi/ginkgo/v2 v2.9.2
 	github.com/onsi/gomega v1.27.5
 	github.com/sirupsen/logrus v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -128,8 +128,8 @@ github.com/cyphar/filepath-securejoin v0.2.3/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxG
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dell/goobjectscale v0.0.0-20230406105044-0add239e0a89 h1:KI14Wpd/GmTXnGfqnON9YIksacEx0ffLuwqyTE71w1Y=
-github.com/dell/goobjectscale v0.0.0-20230406105044-0add239e0a89/go.mod h1:6Dh7WyU0gqCzfPuztPxJ4Gp20Yn5i5IU12a9BJTtd2U=
+github.com/dell/goobjectscale v0.0.0-20230502124457-3303009b54d8 h1:fSOKvf+2gHY5h9aeyy5shIhvdl9wroTSrRmNRq+Tl0o=
+github.com/dell/goobjectscale v0.0.0-20230502124457-3303009b54d8/go.mod h1:6Dh7WyU0gqCzfPuztPxJ4Gp20Yn5i5IU12a9BJTtd2U=
 github.com/denisenkom/go-mssqldb v0.9.0/go.mod h1:xbL0rPBG9cCiLr28tMa8zpbdarY27NDyej4t/EjAShU=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=

--- a/vendor/github.com/dell/goobjectscale/pkg/client/rest/client/simple.go
+++ b/vendor/github.com/dell/goobjectscale/pkg/client/rest/client/simple.go
@@ -52,7 +52,6 @@ type Simple struct {
 
 // MakeRemoteCall executes an API request against the client endpoint, returning
 // the object body of the response into a response object
-// NOTE: this is WET not DRY, as the same code is copied for Client
 func (c *Simple) MakeRemoteCall(r Request, into interface{}) error {
 	err := r.Validate(c.Endpoint)
 	if err != nil {
@@ -135,7 +134,7 @@ func (c *Simple) MakeRemoteCall(r Request, into interface{}) error {
 			if err = Unmarshal(resp, &ecsError); err != nil {
 				return err
 			}
-			return fmt.Errorf("%s: %s", ecsError.Description, ecsError.Details)
+			return ecsError
 		case into == nil:
 			// No errors found, and no response object defined, so just return
 			// without error

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -107,7 +107,7 @@ github.com/cyphar/filepath-securejoin
 # github.com/davecgh/go-spew v1.1.1
 ## explicit
 github.com/davecgh/go-spew/spew
-# github.com/dell/goobjectscale v0.0.0-20230406105044-0add239e0a89
+# github.com/dell/goobjectscale v0.0.0-20230502124457-3303009b54d8
 ## explicit; go 1.18
 github.com/dell/goobjectscale/pkg/client/api
 github.com/dell/goobjectscale/pkg/client/fake


### PR DESCRIPTION
<!--
# Copyright © 2023 Dell Inc. or its subsidiaries. All Rights Reserved.
# 
# Licensed under the Apache License, Version 2.0 (the "License");
# you may not use this file except in compliance with the License.
# You may obtain a copy of the License at
#      http://www.apache.org/licenses/LICENSE-2.0
# Unless required by applicable law or agreed to in writing, software
# distributed under the License is distributed on an "AS IS" BASIS,
# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
# See the License for the specific language governing permissions and
# limitations under the License
-->

# Description
Vendor update mitigating bug in goobjectscale.

> **⚠ Warning**: 
> All changes in `vendor` directory should be placed in separate PRs. Remember about simultaneous merging branches with **vendor** changes and **functionality** changes.
