### PR TITLE
Idempotency for Bucket Access Revoke

### DIFF
--- a/pkg/provisioner/objectscale/driverRevokeBucketAccess.go
+++ b/pkg/provisioner/objectscale/driverRevokeBucketAccess.go
@@ -106,6 +106,7 @@ func (s *Server) DriverRevokeBucketAccess(ctx context.Context, // nolint:gocogni
 			"bucket": bucketName,
 			"error":  err,
 		}).Warn(warnMsg)
+		span.AddEvent("bucket not found")
 		bucketExist = false
 	}
 
@@ -130,6 +131,7 @@ func (s *Server) DriverRevokeBucketAccess(ctx context.Context, // nolint:gocogni
 			"user":  req.AccountId,
 			"error": err,
 		}).Warn(warnMsg)
+		span.AddEvent("user does not exist")
 		userExist = false
 	}
 
@@ -296,7 +298,7 @@ func GetBucketName(bucketID string) (string, error) {
 	list := strings.Split(bucketID, "-")
 
 	if len(list) != 2 { // nolint:gomnd
-		return "", errors.New("improper bucketId")
+		return "", errors.New("invalid bucketId")
 	}
 
 	return list[1], nil

--- a/pkg/provisioner/objectscale/driverRevokeBucketAccess_test.go
+++ b/pkg/provisioner/objectscale/driverRevokeBucketAccess_test.go
@@ -199,13 +199,13 @@ func testInvalidBucketID(t *testing.T) {
 	}
 
 	req := &cosi.DriverRevokeBucketAccessRequest{
-		BucketId:  "bucket-invalid-too-much-dashes",
+		BucketId:  "bucket-invalid-too-many-dashes",
 		AccountId: testUserName,
 	}
 
 	_, err := server.DriverRevokeBucketAccess(ctx, req)
 
-	assert.ErrorIs(t, err, status.Error(codes.InvalidArgument, "improper bucketId"))
+	assert.ErrorIs(t, err, status.Error(codes.InvalidArgument, "invalid bucketId"))
 }
 
 // testEmptyAccountID tests if error handling for empty AccountID in the (*Server).DriverRevokeBucketAccess method.


### PR DESCRIPTION
<!--
# Copyright © 2023 Dell Inc. or its subsidiaries. All Rights Reserved.
# 
# Licensed under the Apache License, Version 2.0 (the "License");
# you may not use this file except in compliance with the License.
# You may obtain a copy of the License at
#      http://www.apache.org/licenses/LICENSE-2.0
# Unless required by applicable law or agreed to in writing, software
# distributed under the License is distributed on an "AS IS" BASIS,
# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
# See the License for the specific language governing permissions and
# limitations under the License
-->

# Description
Changed access revoke flow so it follows idempotency concept required by COSI spec

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Unit testing
- [ ] Integration testing

# Special Notes For Your Reviewer:
Please describe the parts of code reviewers should focus on.

# Additional documentation
- [ ] Enhancement proposals
- [ ] Usage documentation