### PR TITLE
Use go base image

### DIFF
--- a/.github/workflows/development.yaml
+++ b/.github/workflows/development.yaml
@@ -29,7 +29,7 @@ jobs:
           echo "machine github.com login csmbot password $TOKEN" >> ~/.netrc
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.22"
           cache: false
       - name: Checkout the code
         uses: actions/checkout@v4.1.0
@@ -89,7 +89,7 @@ jobs:
           args: ./scripts/*
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.22"
           cache: false
       - name: Install and run Checkmake
         run: |
@@ -133,7 +133,7 @@ jobs:
           echo "machine github.com login csmbot password $TOKEN" >> ~/.netrc
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.22"
           cache: false
       - name: Checkout the code
         uses: actions/checkout@v4.1.0

--- a/.github/workflows/development.yaml
+++ b/.github/workflows/development.yaml
@@ -27,7 +27,7 @@ jobs:
         run: |
           git config --global url."https://csmbot:$TOKEN@github.com".insteadOf "https://github.com"
           echo "machine github.com login csmbot password $TOKEN" >> ~/.netrc
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: "1.21"
           cache: false
@@ -87,7 +87,7 @@ jobs:
         uses: Difegue/action-perlcritic@master
         with:
           args: ./scripts/*
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: "1.21"
           cache: false
@@ -131,7 +131,7 @@ jobs:
         run: |
           git config --global url."https://csmbot:$TOKEN@github.com".insteadOf "https://github.com"
           echo "machine github.com login csmbot password $TOKEN" >> ~/.netrc
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: "1.21"
           cache: false

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,7 +20,7 @@ run:
 
   # Define the Go version limit.
   # Mainly related to generics support since go1.18.
-  # Default: use Go version from the go.mod file, fallback on the env var `GOVERSION`, fallback on 1.18
+  # Default: use Go version from the go.mod file, fallback on the env var `GOIMAGE`, fallback on 1.18
   # Intentionally left empty to use go.mod's Go version
   go: ""
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,11 +12,11 @@
 
 # BASEIMAGE is a base image for final COSI-Driver container.
 ARG BASEIMAGE
-# GOVERSION is a Go version used for bulding driver.
-ARG GOVERSION
+# GOIMAGE is a Go version used for bulding driver.
+ARG GOIMAGE
 
 # First stage: building binary of the driver.
-FROM golang:${GOVERSION} as builder
+FROM $GOIMAGE as builder
 
 WORKDIR /workspace
 

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ docker: vendor download-csm-common ##build the docker container
 	$(eval include csm-common.mk)
 	@echo "Base Images is set to: $(DEFAULT_BASEIMAGE)"
 	@echo "Building: $(IMAGENAME):$(IMAGETAG)"
-	docker build --pull -t "$(IMAGENAME):$(IMAGETAG)" --build-arg BASEIMAGE=$(DEFAULT_BASEIMAGE) --build-arg GOVERSION=$(GOVERSION) .
+	docker build --pull -t "$(IMAGENAME):$(IMAGETAG)" --build-arg BASEIMAGE=$(DEFAULT_BASEIMAGE) --build-arg GOIMAGE=$(DEFAULT_GOIMAGE) .
 
 .PHONY: push
 push: docker	##build and push the docker container to repository

--- a/overrides.mk
+++ b/overrides.mk
@@ -12,11 +12,11 @@
 
 # overrides.mk file
 # This file, included from the Makefile, will overlay default values with environment variables:
-# GOVERSION, REGISTRY, IMAGENAME, IMAGETAG.
+# GOIMAGE, REGISTRY, IMAGENAME, IMAGETAG.
 
 # DEFAULT values
-# GOVERSION is a build version for driver.
-DEFAULT_GOVERSION:=$(shell sed -En 's/^go (.*)$$/\1/p' go.mod)
+# GOIMAGE is the version of Go.
+DEFAULT_GOIMAGE:=$(shell sed -En 's/^go (.*)$$/\1/p' go.mod)
 # REGISTRY in which COSI image resides.
 DEFAULT_REGISTRY=docker.io
 # IMAGENAME is COSI image name.
@@ -24,9 +24,9 @@ DEFAULT_IMAGENAME=dell/cosi
 # IMAGETAG by default is latest commit SHA.
 DEFAULT_IMAGETAG:=$(shell git rev-parse HEAD)
 
-# set the GOVERSION if needed
-ifeq ($(GOVERSION),)
-export GOVERSION="$(DEFAULT_GOVERSION)"
+# set the GOIMAGE if needed
+ifeq ($(GOIMAGE),)
+export GOIMAGE="$(DEFAULT_GOIMAGE)"
 endif
 
 # set the REGISTRY if needed
@@ -49,8 +49,8 @@ overrides-help:
 	@echo
 	@echo "The following environment variables can be set to control the build"
 	@echo
-	@echo "GOVERSION   - The version of Go to build with, default is: $(DEFAULT_GOVERSION)"
-	@echo "              Current setting is: $(GOVERSION)"
+	@echo "GOIMAGE     - The version of Go to build with, default is: $(DEFAULT_GOIMAGE)"
+	@echo "              Current setting is: $(GOIMAGE)"
 	@echo "REGISTRY    - The registry to push images to, default is: $(DEFAULT_REGISTRY)"
 	@echo "              Current setting is: $(REGISTRY)"
 	@echo "IMAGENAME   - The image name to be built, defaut is: $(DEFAULT_IMAGENAME)"


### PR DESCRIPTION
<!--
# Copyright © 2023 Dell Inc. or its subsidiaries. All Rights Reserved.
# 
# Licensed under the Apache License, Version 2.0 (the "License");
# you may not use this file except in compliance with the License.
# You may obtain a copy of the License at
#      http://www.apache.org/licenses/LICENSE-2.0
# Unless required by applicable law or agreed to in writing, software
# distributed under the License is distributed on an "AS IS" BASIS,
# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
# See the License for the specific language governing permissions and
# limitations under the License
-->

# Description
Changes to point to Default go image version in common.mk file.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1098 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
Image build:
![image](https://github.com/dell/cosi/assets/92028646/e867a54d-e1a3-4146-8a38-1feda3f3f6be)
